### PR TITLE
redirect 404 to stdout instead of stderr

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -7,9 +7,9 @@ FILE_PATH="${FILE_PATH}""/"
                                                                                                                                                                         
 echo "$FILE_PATH""$FILE"                                                                                                                                                
 TAR_MD5_SUM=$(openssl md5 -binary "$FILE_PATH$FILE".tar.gz | base64)                                                                                                    
-SQL_MD5_SUM=$(openssl md5 -binary $FILE_PATH$FILE".sql" | base64)                                                                                                       
-REMOTE_SQL_MD5_SUM=$(aws s3api head-object --bucket $BUCKET --key "$FILE".tar.gz --query 'Metadata.sqlmd5checksum' --output text)
-                                                                                                                                                                        
+SQL_MD5_SUM=$(openssl md5 -binary $FILE_PATH$FILE".sql" | base64)   
+REMOTE_SQL_MD5_SUM=$(aws s3api head-object --bucket $BUCKET --key "$FILE".tar.gz --query 'Metadata.sqlmd5checksum' --output text 2>&1) || (if grep -q "An error occurred (404) when calling the HeadObject operation: Not Found" <<< "$REMOTE_SQL_MD5_SUM"; then echo "$REMOTE_SQL_MD5_SUM"; else echo "$REMOTE_SQL_MD5_SUM" 1>&2; fi)                                                                                                                                                         
+
 echo $SQL_MD5_SUM                                                                                                                                                       
 echo $REMOTE_SQL_MD5_SUM                                                                                                                                                
                                                                                                                                                                         


### PR DESCRIPTION
This PR closes this [issue](https://github.com/getfundwave/production/issues/35).

Earlier 404 was sent to stderr, now 404 is redirected to stdout.
```
var=$(command 2>&1) || (if grep -q "An error occurred (404) when calling the HeadObject operation: Not Found" <<< "$var"; then echo "$var"; else echo "$var" 1>&2; fi) 
```