### PR TITLE
Workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,41 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: ["main"]
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: fundwave/s3-mysql-backup-cron
+          tags: |
+            # type=ref,event=branch
+            type=sha,enable=true,prefix=sha-,format=short
+            # type=semver,pattern={{version}}
+            # type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=true
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
In reference to issue https://github.com/getfundwave/s3-db-backup-cron/issues/1
This PR adds github action to publish image to docker hub.

It publishes two images to docker hub with tag names:

- latest
- commit sha (eg. sha-f87d7b7)

Secrets to add:

- DOCKER_USERNAME 

- DOCKER_PASSWORD